### PR TITLE
Fix/api deadlock

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1231,13 +1231,13 @@ std::set<JsonRpcConnection::Ptr> ApiListener::GetAnonymousClients(void) const
 
 void ApiListener::AddHttpClient(const HttpServerConnection::Ptr& aclient)
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_HttpLock);
 	m_HttpClients.insert(aclient);
 }
 
 void ApiListener::RemoveHttpClient(const HttpServerConnection::Ptr& aclient)
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_HttpLock);
 	m_HttpClients.erase(aclient);
 }
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -134,6 +134,7 @@ private:
 	WorkQueue m_RelayQueue;
 	WorkQueue m_SyncQueue;
 
+	boost::mutex m_HttpLock;
 	boost::mutex m_LogLock;
 	Stream::Ptr m_LogFile;
 	size_t m_LogMessageCount;


### PR DESCRIPTION
Tested with 10 passive services on 52 hosts, check now created 99 threads and went back to 38.
Seems stable, don't now if the loop in HttpServerConnection::TimeoutTimerHandler will not give a problem without the HttpLock